### PR TITLE
Add explicit namespaces to all namespaced resources in Helm charts

### DIFF
--- a/deploy/example-webhook/templates/deployment.yaml
+++ b/deploy/example-webhook/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "example-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "example-webhook.name" . }}
     chart: {{ include "example-webhook.chart" . }}

--- a/deploy/example-webhook/templates/rbac.yaml
+++ b/deploy/example-webhook/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "example-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "example-webhook.name" . }}
     chart: {{ include "example-webhook.chart" . }}

--- a/deploy/example-webhook/templates/service.yaml
+++ b/deploy/example-webhook/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "example-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "example-webhook.name" . }}
     chart: {{ include "example-webhook.chart" . }}


### PR DESCRIPTION
A few resources didn't specify a namespace, resulting in a discrepency if `helm template --namespace` is ran and later `kubectl apply` happens to be in a different context.