### PR TITLE
Improve documentation of groupName in the helm values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ webhook to complete ACME challenge validations and obtain certificates.
 To make the set up of these webhook's easier, we provide a template repository
 that can be used to get started quickly.
 
+When implementing your webhook, you should set the `groupName` in the
+[values.yml](deploy/example-webhook/values.yaml) of your chart to a domain name that 
+you - as the webhook-author - own. It should not need to be adjusted by the users of
+your chart.
+
 ### Creating your own repository
 
 ### Running the test suite

--- a/deploy/example-webhook/values.yaml
+++ b/deploy/example-webhook/values.yaml
@@ -1,11 +1,13 @@
-# The GroupName here is used to identify your company or business unit that
-# created this webhook.
-# For example, this may be "acme.mycompany.com".
-# This name will need to be referenced in each Issuer's `webhook` stanza to
+# The groupName avoids naming conflicts on the Kubernetes API, it should be set by the
+# author of the webhook a unique domain that the author owns. For
+# example: some-provider-webhook.mycompany.tld , or
+# some-provider-webhook.mypersonalsite.tld if your webhook is a personal open-source
+# project.
+# Once set to a unique domain name by the webhook author, it does not need to be further
+# adjusted by the users of a webhook chart!
+# The name will need to be referenced in each Issuer's `webhook` stanza to
 # inform cert-manager of where to send ChallengePayload resources in order to
 # solve the DNS01 challenge.
-# This group name should be **unique**, hence using your own company's domain
-# here is recommended.
 groupName: acme.mycompany.com
 
 certManager:


### PR DESCRIPTION
It seems that the function of `groupName` in the values of the helmchart is frequently misunderstood with some webhook-charts advising chart-users to specify it, leading to friction and confusion.

I hope to clarify the relevant documentation with this PR.

Related:  

https://github.com/vadimkim/cert-manager-webhook-hetzner/issues/92
https://github.com/vadimkim/cert-manager-webhook-hetzner/pull/95
https://github.com/Luzifer/cert-manager-desec-webhook/pull/2
