### PR TITLE
Update OWNERS file to match current state

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,13 +4,17 @@ approvers:
 - wallrj
 - jakexks
 - maelvls
-- irbekrm
 - inteon
+- sgtcodfish
+- erikgb
+- thatsmrtalbot
 reviewers:
 - munnerz
 - joshvanl
 - wallrj
 - jakexks
 - maelvls
-- irbekrm
 - inteon
+- sgtcodfish
+- erikgb
+- thatsmrtalbot


### PR DESCRIPTION
I don't have time to fully fix this using aliases like we have elsewhere, but this:

1. Adds me and Erik, since we're both active maintainers
2. Removes Irbe (who's now an emeritus maintainer)