### PR TITLE
Fix broken link in type docs

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 
+	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook/cmd"
 )
@@ -31,8 +32,9 @@ func main() {
 
 // customDNSProviderSolver implements the provider-specific logic needed to
 // 'present' an ACME challenge TXT record for your own DNS provider.
-// To do so, it must implement the `github.com/cert-manager/cert-manager/pkg/acme/webhook.Solver`
-// interface.
+//
+// It must implement the [webhook.Solver] interface:
+// https://pkg.go.dev/github.com/cert-manager/cert-manager/pkg/acme/webhook#Solver
 type customDNSProviderSolver struct {
 	// If a Kubernetes 'clientset' is needed, you must:
 	// 1. uncomment the additional `client` field in this structure below
@@ -42,6 +44,8 @@ type customDNSProviderSolver struct {
 	//    assigned to it for interacting with the Kubernetes APIs you need.
 	//client kubernetes.Clientset
 }
+
+var _ webhook.Solver = (*customDNSProviderSolver)(nil)
 
 // customDNSProviderConfig is a structure that is used to decode into when
 // solving a DNS01 challenge.


### PR DESCRIPTION
The current link is returning 404. Reported by Max Roby on Slack: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1782042111235629